### PR TITLE
Add manual release and Homebrew Cask pipeline

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,76 @@
+name: Homebrew Tap
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to Homebrew, e.g. v0.1.1."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          mkdir -p source/release
+          cd source/release
+          gh release download "${TAG}" -p "SHA256SUMS"
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: tap
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+
+      - name: Generate Cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ inputs.tag }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid release tag: ${TAG}"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "::error::Homebrew publishes stable releases only: ${TAG}"
+            exit 1
+          fi
+          bash source/scripts/release/generate_homebrew_cask.sh \
+            "${VERSION}" \
+            source/release/SHA256SUMS \
+            tap/Casks/pr-monitor.rb \
+            guibeira \
+            pr-monitor
+
+      - name: Commit and push Cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          cd tap
+          git add Casks/pr-monitor.rb
+          if git diff --cached --quiet -- Casks/pr-monitor.rb; then
+            echo "No Cask changes; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "release: pr-monitor ${VERSION}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,118 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. 0.1.1 or 0.1.1-rc1. Do not include leading v."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate and show changes without committing or tagging."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+
+      - name: Validate version format
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected X.Y.Z or X.Y.Z-(rc|alpha|beta|pre)N."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag does not already exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.validate.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists locally."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists on origin."
+            exit 1
+          fi
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Update project versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          node scripts/release/set_version.mjs "${VERSION}"
+          cargo update --manifest-path src-tauri/Cargo.toml -p pull-request-monitor
+          git --no-pager diff -- package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+
+      - name: Show changes
+        if: ${{ inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Dry run enabled. Changes that would be committed:"
+          git --no-pager diff -- package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          echo "Tag that would be created: ${{ steps.validate.outputs.tag }}"
+
+      - name: Commit and tag release
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.validate.outputs.version }}"
+          TAG="${{ steps.validate.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          if git diff --cached --quiet; then
+            echo "::error::No changes staged. Version may already be set to ${VERSION}."
+            exit 1
+          fi
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin "${TAG}"
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## Manual Release"
+            echo ""
+            echo "- Version: \`${{ steps.validate.outputs.version }}\`"
+            echo "- Tag: \`${{ steps.validate.outputs.tag }}\`"
+            echo "- Branch: \`${GITHUB_REF_NAME}\`"
+            echo "- Dry run: \`${{ inputs.dry_run }}\`"
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              echo ""
+              echo "The \`Release\` workflow will build the macOS assets and publish the Homebrew Cask."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,227 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid release tag: ${GITHUB_REF_NAME}"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify tag matches project versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          CARGO_VERSION=$(
+            awk '
+              /^\[package\]/ { in_pkg = 1; next }
+              /^\[/          { in_pkg = 0 }
+              in_pkg && /^version[[:space:]]*=/ {
+                match($0, /"[^"]*"/)
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            ' src-tauri/Cargo.toml
+          )
+          PACKAGE_VERSION="$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+          TAURI_VERSION="$(node -p "JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json', 'utf8')).version")"
+          for version_file in \
+            "package.json:${PACKAGE_VERSION}" \
+            "src-tauri/Cargo.toml:${CARGO_VERSION}" \
+            "src-tauri/tauri.conf.json:${TAURI_VERSION}"
+          do
+            file="${version_file%%:*}"
+            file_version="${version_file#*:}"
+            if [[ "$TAG_VERSION" != "$file_version" ]]; then
+              echo "::error::Tag version '${TAG_VERSION}' does not match ${file}='${file_version}'."
+              exit 1
+            fi
+          done
+
+  build-dmg:
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+          - os: macos-15
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add "${{ matrix.target }}"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+
+      - name: Install frontend dependencies
+        shell: bash
+        run: npm ci
+
+      - name: Build DMG
+        shell: bash
+        run: npm exec -- tauri build --bundles dmg --target "${{ matrix.target }}"
+
+      - name: Normalize DMG name
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate.outputs.version }}"
+          TARGET="${{ matrix.target }}"
+          mkdir -p release
+          DMG_PATH="$(find "src-tauri/target/${TARGET}/release/bundle/dmg" -maxdepth 1 -name "*.dmg" -print -quit)"
+          if [[ -z "${DMG_PATH}" ]]; then
+            echo "::error::No DMG found for ${TARGET}."
+            exit 1
+          fi
+          cp "${DMG_PATH}" "release/pr-monitor-${VERSION}-${TARGET}.dmg"
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ matrix.target }}
+          path: release/pr-monitor-${{ needs.validate.outputs.version }}-${{ matrix.target }}.dmg
+          retention-days: 1
+
+  github-release:
+    needs:
+      - validate
+      - build-dmg
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download DMGs
+        uses: actions/download-artifact@v8
+        with:
+          path: release
+          merge-multiple: true
+          pattern: release-*
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release
+          sha256sum -- *.dmg > SHA256SUMS
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ needs.validate.outputs.version }}
+          generate_release_notes: true
+          files: |
+            release/*.dmg
+            release/SHA256SUMS
+          draft: false
+          prerelease: ${{ needs.validate.outputs.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-homebrew:
+    needs:
+      - validate
+      - github-release
+    if: ${{ needs.validate.outputs.prerelease == 'false' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: Download release checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p source/release
+          cd source/release
+          gh release download "${GITHUB_REF_NAME}" -p "SHA256SUMS"
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: tap
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+
+      - name: Generate Cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.validate.outputs.version }}"
+          bash source/scripts/release/generate_homebrew_cask.sh \
+            "${VERSION}" \
+            source/release/SHA256SUMS \
+            tap/Casks/pr-monitor.rb \
+            guibeira \
+            pr-monitor
+
+      - name: Commit and push Cask
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd tap
+          git add Casks/pr-monitor.rb
+          if git diff --cached --quiet -- Casks/pr-monitor.rb; then
+            echo "No Cask changes; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "release: pr-monitor ${{ needs.validate.outputs.version }}"
+          git push origin "HEAD:${{ github.event.repository.default_branch }}"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ PR Monitor is a desktop utility for developers that lives in your system tray/me
 We currently only support MacOS, but we plan to add Windows support in the future.
 
 ## How to install
-To install the application, you will need [Rust](https://www.rust-lang.org/tools/install) and [Node.js](https://nodejs.org/) installed.
+### Using Homebrew
+
+```bash
+brew tap guibeira/pr-monitor https://github.com/guibeira/pr-monitor
+brew install --cask pr-monitor
+```
+
+### Building from source
+
+To install the application from source, you will need [Rust](https://www.rust-lang.org/tools/install) and [Node.js](https://nodejs.org/) installed.
 
 Now install the tauri CLI tool, which is required to build and run the application.
 ```bash
@@ -76,4 +85,3 @@ Navigate to the **Settings** tab to configure the application:
 
 - **Refresh Time:** Set how often (in minutes) the app should check your pull requests for updates.
 - **Show Notifications:** Toggle desktop notifications for PR status changes on or off.
-

--- a/scripts/release/generate_homebrew_cask.sh
+++ b/scripts/release/generate_homebrew_cask.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "usage: $0 <version> <checksums_file> <output_file> [owner] [repo]" >&2
+  exit 1
+fi
+
+version="$1"
+checksums_file="$2"
+output_file="$3"
+owner="${4:-guibeira}"
+repo="${5:-pr-monitor}"
+
+if [ ! -f "${checksums_file}" ]; then
+  echo "checksums file not found: ${checksums_file}" >&2
+  exit 1
+fi
+
+darwin_x64_dmg="pr-monitor-${version}-x86_64-apple-darwin.dmg"
+darwin_arm64_dmg="pr-monitor-${version}-aarch64-apple-darwin.dmg"
+
+lookup_sha() {
+  local asset_name="$1"
+  awk -v target="${asset_name}" '$2 == target { print $1 }' "${checksums_file}"
+}
+
+darwin_x64_sha="$(lookup_sha "${darwin_x64_dmg}")"
+darwin_arm64_sha="$(lookup_sha "${darwin_arm64_dmg}")"
+
+test -n "${darwin_x64_sha}"
+test -n "${darwin_arm64_sha}"
+
+mkdir -p "$(dirname "${output_file}")"
+
+cat > "${output_file}" <<EOF
+cask "pr-monitor" do
+  arch arm: "aarch64-apple-darwin", intel: "x86_64-apple-darwin"
+
+  version "${version}"
+  sha256 arm:   "${darwin_arm64_sha}",
+         intel: "${darwin_x64_sha}"
+
+  url "https://github.com/${owner}/${repo}/releases/download/v#{version}/pr-monitor-#{version}-#{arch}.dmg",
+      verified: "github.com/${owner}/${repo}/"
+  name "PR Monitor"
+  desc "Desktop utility for monitoring and updating GitHub pull requests"
+  homepage "https://github.com/${owner}/${repo}"
+
+  app "Pull request monitor.app"
+
+  zap trash: [
+    "~/Library/Application Support/pr-monitor.guibeira.dev",
+    "~/Library/Caches/pr-monitor.guibeira.dev",
+    "~/Library/Logs/pr-monitor.guibeira.dev",
+    "~/Library/Preferences/pr-monitor.guibeira.dev.plist",
+    "~/Library/WebKit/pr-monitor.guibeira.dev",
+  ]
+end
+EOF

--- a/scripts/release/set_version.mjs
+++ b/scripts/release/set_version.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error("usage: set_version.mjs <version>");
+  process.exit(1);
+}
+
+if (!/^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$/.test(version)) {
+  console.error(`invalid version: ${version}`);
+  process.exit(1);
+}
+
+function writeJson(path, update) {
+  const data = JSON.parse(fs.readFileSync(path, "utf8"));
+  update(data);
+  fs.writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+writeJson("package.json", (data) => {
+  data.version = version;
+});
+
+writeJson("package-lock.json", (data) => {
+  data.version = version;
+  if (data.packages?.[""]) {
+    data.packages[""].version = version;
+  }
+});
+
+writeJson("src-tauri/tauri.conf.json", (data) => {
+  data.version = version;
+});
+
+const cargoPath = "src-tauri/Cargo.toml";
+const cargoToml = fs.readFileSync(cargoPath, "utf8");
+const nextCargoToml = cargoToml.replace(
+  /(\[package\][\s\S]*?\nversion\s*=\s*)"[^"]*"/,
+  `$1"${version}"`,
+);
+
+if (nextCargoToml === cargoToml && !cargoToml.includes(`version = "${version}"`)) {
+  console.error("failed to locate [package] version in src-tauri/Cargo.toml");
+  process.exit(1);
+}
+
+fs.writeFileSync(cargoPath, nextCargoToml);


### PR DESCRIPTION
## Summary

- Add a manual release workflow that accepts a version, supports dry runs, updates project version files, commits, and tags `vX.Y.Z`.
- Add a tag-triggered release workflow that builds macOS DMGs for Intel and Apple Silicon, creates GitHub Release assets, and updates the Homebrew Cask for stable releases.
- Add a manual Homebrew republish workflow and release helper scripts.
- Document Homebrew installation and the release process in the README.

## Notes

This intentionally skips crates.io publishing. Because PR Monitor is a Tauri macOS app, Homebrew support is implemented as a Cask using the generated DMG release assets.

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest`
- `docker run --rm -v "$PWD:/repo" -w /repo koalaman/shellcheck:stable scripts/release/generate_homebrew_cask.sh`
- `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work node:22-bookworm ...`
- `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/work" -w /work rust:1.88.0-bookworm cargo update --manifest-path src-tauri/Cargo.toml -p pull-request-monitor`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation option for simplified setup

* **Documentation**
  * Expanded installation instructions with Homebrew alternative and explicit Rust/Node.js prerequisites for building from source

* **Chores**
  * Implemented automated release workflows for publishing releases to GitHub and Homebrew with version validation and artifact generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibeira/pr-monitor/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->