### PR TITLE
Dispatch release workflow after manual tag

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: write
 
     steps:
@@ -24,7 +25,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Validate version format
         id: validate
@@ -99,6 +99,14 @@ jobs:
           fi
           git tag -a "${TAG}" -m "Release ${TAG}"
           git push origin "${TAG}"
+
+      - name: Dispatch release workflow
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.validate.outputs.tag }}
+        run: gh workflow run release.yml --ref "${GITHUB_REF_NAME}" -f tag="${TAG}"
 
       - name: Summary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, e.g. v0.1.1."
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,31 +20,46 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       prerelease: ${{ steps.version.outputs.prerelease }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
-      - name: Extract version from tag
+      - name: Resolve release tag
         id: version
         shell: bash
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag || '' }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
-            echo "::error::Invalid release tag: ${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid release tag: ${TAG}"
             exit 1
           fi
+          VERSION="${TAG#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)[0-9]*)?$ ]]; then
+            echo "::error::Invalid release version: ${VERSION}"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if [[ "$VERSION" =~ (rc|alpha|beta|pre) ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
 
       - name: Verify tag matches project versions
         shell: bash
@@ -85,6 +106,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -158,7 +181,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ needs.validate.outputs.tag }}
           name: Release ${{ needs.validate.outputs.version }}
           generate_release_notes: true
           files: |
@@ -182,6 +205,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: source
+          ref: ${{ needs.validate.outputs.tag }}
 
       - name: Download release checksums
         env:
@@ -190,7 +214,7 @@ jobs:
           set -euo pipefail
           mkdir -p source/release
           cd source/release
-          gh release download "${GITHUB_REF_NAME}" -p "SHA256SUMS"
+          gh release download "${{ needs.validate.outputs.tag }}" -p "SHA256SUMS"
 
       - name: Checkout tap repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Dispatch the `Release` workflow explicitly after `Manual Release` creates a tag.
- Add `workflow_dispatch` support to `Release` with a `tag` input.
- Make `Release` checkout and publish against the resolved tag for both tag-push and manual dispatch events.

## Root Cause

The `v0.1.0` tag was created by the manual workflow, but the `Release` workflow did not run. GitHub does not create new workflow runs for most events caused by `GITHUB_TOKEN`, including tag `push` events. `workflow_dispatch` is an allowed exception, so the manual release workflow now triggers the release workflow directly.

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest`
- `git diff --check`
