### PR TITLE
Fix macOS Homebrew Gatekeeper install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PR Monitor is a desktop utility for developers that lives in your system tray/me
 - **Status Notifications:** Get notified of PR status changes, such as merge conflicts or blocks.
 - **Configurable:** Adjust the refresh interval and toggle notifications to fit your workflow.
 
-We currently only support MacOS, but we plan to add Windows support in the future.
+PR Monitor currently supports macOS only.
 
 ## How to install
 ### Using Homebrew

--- a/scripts/release/generate_homebrew_cask.sh
+++ b/scripts/release/generate_homebrew_cask.sh
@@ -49,6 +49,12 @@ cask "pr-monitor" do
 
   app "Pull request monitor.app"
 
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-d", "com.apple.quarantine", "#{appdir}/Pull request monitor.app"],
+                   sudo: false
+  end
+
   zap trash: [
     "~/Library/Application Support/pr-monitor.guibeira.dev",
     "~/Library/Caches/pr-monitor.guibeira.dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

- Configure Tauri macOS bundles to use ad-hoc signing (`signingIdentity: "-"`).
- Update the generated Homebrew Cask to remove the quarantine attribute from the installed app bundle.
- Clarify in the README that PR Monitor currently supports macOS only.

## Root Cause

The DMG installed via Homebrew, but macOS Gatekeeper rejected the app as damaged. The installed app had a quarantine attribute and `codesign` reported an invalid bundle signature (`code has no resources but signature indicates they must be present`).

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo koalaman/shellcheck:stable scripts/release/generate_homebrew_cask.sh`
- Generated a sample Cask and checked the `postflight` quarantine removal stanza.
- Parsed `src-tauri/tauri.conf.json` with Node.
- `git diff --check`
- Built the macOS arm64 app locally up to Tauri's local `xattr` bundling step; manually applying `codesign --force --deep --sign -` to the generated `.app` made `codesign --verify --deep --strict` pass.

## Notes

The already-published `v0.1.1` DMG still contains the old bundle. After this merges, publish a new patch release so the Cask points to fresh DMGs.
