### PR TITLE
Fix tray window positioning panic

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -1,11 +1,14 @@
 use crate::credentials::CredentialStore;
+use crate::diagnostics;
 use crate::error::{AppError, AppResult};
 use crate::monitor::Monitor;
 use crate::storage::Storage;
+use log::LevelFilter;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::plugin::TauriPlugin;
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{window::Color, Manager};
-use tauri_plugin_positioner::WindowExt;
+use tauri::{window::Color, Manager, PhysicalPosition, PhysicalSize, Rect, Runtime, WebviewWindow};
+use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
 pub struct AppState {
     pub credentials: CredentialStore,
@@ -25,7 +28,10 @@ impl AppState {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    diagnostics::install_panic_hook();
+
+    let run_result = tauri::Builder::default()
+        .plugin(log_plugin())
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Focused(false) = event {
                 let _ = window.hide();
@@ -46,6 +52,8 @@ pub fn run() {
             std::fs::create_dir_all(&app_data_dir)?;
             let db_path = app_data_dir.join("monitor.db");
             app.manage(AppState::new(db_path)?);
+            log::info!("App initialized");
+            log::info!("Log directory: {}", diagnostics::app_log_dir().display());
 
             let quit = MenuItemBuilder::new("Quit").id("quit").build(app)?;
             let menu = MenuBuilder::new(app).items(&[&quit]).build()?;
@@ -64,14 +72,16 @@ pub fn run() {
                     if let TrayIconEvent::Click {
                         button: MouseButton::Left,
                         button_state: MouseButtonState::Up,
+                        rect,
                         ..
                     } = event
                     {
                         if let Some(window) = app.get_webview_window("main") {
                             if !window.is_visible().unwrap_or(false) {
-                                let _ = window.move_window(
-                                    tauri_plugin_positioner::Position::TrayBottomCenter,
-                                );
+                                if let Err(err) = move_window_to_tray_bottom_center(&window, &rect)
+                                {
+                                    log::warn!("Failed to position tray window: {err}");
+                                }
                                 let _ = window.show();
                                 let _ = window.set_focus();
                             } else {
@@ -89,7 +99,6 @@ pub fn run() {
 
             Ok(())
         })
-        .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
             crate::commands::add_item,
@@ -108,6 +117,39 @@ pub fn run() {
             crate::commands::get_theme,
             crate::commands::set_theme
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .run(tauri::generate_context!());
+
+    if let Err(err) = run_result {
+        log::error!("error while running tauri application: {err}");
+        diagnostics::record_fatal_error("error while running tauri application", &err);
+        eprintln!("error while running tauri application: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn log_plugin<R: Runtime>() -> TauriPlugin<R> {
+    tauri_plugin_log::Builder::new()
+        .targets([
+            Target::new(TargetKind::Stdout),
+            Target::new(TargetKind::LogDir { file_name: None }),
+        ])
+        .rotation_strategy(RotationStrategy::KeepAll)
+        .timezone_strategy(TimezoneStrategy::UseLocal)
+        .max_file_size(1_000_000)
+        .level(LevelFilter::Info)
+        .build()
+}
+
+fn move_window_to_tray_bottom_center<R: Runtime>(
+    window: &WebviewWindow<R>,
+    rect: &Rect,
+) -> tauri::Result<()> {
+    let tray_position: PhysicalPosition<f64> = rect.position.to_physical(1.0);
+    let tray_size: PhysicalSize<f64> = rect.size.to_physical(1.0);
+    let window_size = window.outer_size()?;
+
+    let x = tray_position.x + (tray_size.width / 2.0) - (window_size.width as f64 / 2.0);
+    let y = tray_position.y;
+
+    window.set_position(PhysicalPosition::new(x.round() as i32, y.round() as i32))
 }

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,103 @@
+use std::backtrace::Backtrace;
+use std::fmt::Write as FmtWrite;
+use std::io::Write as IoWrite;
+use std::path::PathBuf;
+use std::sync::Once;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const APP_IDENTIFIER: &str = "pr-monitor.guibeira.dev";
+
+static PANIC_HOOK: Once = Once::new();
+
+pub fn install_panic_hook() {
+    PANIC_HOOK.call_once(|| {
+        let default_hook = std::panic::take_hook();
+
+        std::panic::set_hook(Box::new(move |panic_info| {
+            let current_thread = std::thread::current();
+            let thread_name = current_thread.name().unwrap_or("<unnamed>");
+            let payload = if let Some(message) = panic_info.payload().downcast_ref::<&str>() {
+                (*message).to_owned()
+            } else if let Some(message) = panic_info.payload().downcast_ref::<String>() {
+                message.clone()
+            } else {
+                "<non-string panic payload>".to_owned()
+            };
+
+            let mut details = String::new();
+            let _ = writeln!(details, "timestamp_unix: {}", timestamp_unix());
+            let _ = writeln!(details, "version: {}", env!("CARGO_PKG_VERSION"));
+            let _ = writeln!(details, "pid: {}", std::process::id());
+            let _ = writeln!(details, "thread: {thread_name}");
+            let _ = writeln!(details, "payload: {payload}");
+
+            if let Some(location) = panic_info.location() {
+                let _ = writeln!(
+                    details,
+                    "location: {}:{}:{}",
+                    location.file(),
+                    location.line(),
+                    location.column()
+                );
+            }
+
+            let _ = writeln!(details, "backtrace:\n{}", Backtrace::force_capture());
+
+            append_diagnostic("panic.log", &details);
+            default_hook(panic_info);
+        }));
+    });
+}
+
+pub fn record_fatal_error(context: &str, err: &impl std::fmt::Display) {
+    let mut details = String::new();
+    let _ = writeln!(details, "timestamp_unix: {}", timestamp_unix());
+    let _ = writeln!(details, "version: {}", env!("CARGO_PKG_VERSION"));
+    let _ = writeln!(details, "pid: {}", std::process::id());
+    let _ = writeln!(details, "context: {context}");
+    let _ = writeln!(details, "error: {err}");
+    let _ = writeln!(details, "backtrace:\n{}", Backtrace::force_capture());
+
+    append_diagnostic("fatal.log", &details);
+}
+
+pub fn app_log_dir() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home)
+            .join("Library")
+            .join("Logs")
+            .join(APP_IDENTIFIER);
+    }
+
+    std::env::temp_dir().join(APP_IDENTIFIER).join("logs")
+}
+
+fn append_diagnostic(file_name: &str, details: &str) {
+    let log_dir = app_log_dir();
+    if let Err(err) = std::fs::create_dir_all(&log_dir) {
+        eprintln!("failed to create diagnostic log directory {log_dir:?}: {err}");
+        return;
+    }
+
+    let log_file = log_dir.join(file_name);
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_file)
+    {
+        Ok(mut file) => {
+            let _ = writeln!(file, "==== diagnostic event ====");
+            let _ = file.write_all(details.as_bytes());
+            let _ = writeln!(file);
+        }
+        Err(err) => eprintln!("failed to open diagnostic log file {log_file:?}: {err}"),
+    }
+}
+
+fn timestamp_unix() -> String {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => format!("{}.{:03}", duration.as_secs(), duration.subsec_millis()),
+        Err(_) => "before-unix-epoch".to_owned(),
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 mod commands;
 mod credentials;
+mod diagnostics;
 pub mod domain;
 pub mod error;
 pub mod github;


### PR DESCRIPTION
## Summary
- Add persistent panic and fatal-error diagnostics under the app log directory.
- Configure Tauri logging explicitly with kept rotated log files.
- Avoid the tray positioning panic by positioning the window from the tray event rect instead of calling the positioner monitor lookup path.

## Root Cause
The crash was a Rust panic from `tauri-plugin-positioner` while resolving the current monitor on macOS. In the failing path, Tao received `NULL` from `-[NSKVONotifying_TaoWindow screen]`, which made the app exit with status 101.

## Impact
The tray click path no longer depends on that monitor lookup, so the app should stop closing when macOS temporarily reports no screen for the window. If a future fatal error happens, the logs now persist enough detail to inspect it after the app exits.

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run build`
- `PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH" npm exec tauri build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app startup and logging, including clearer initialization messages and a dedicated log location.
  * Added more robust crash and fatal error reporting to help capture unexpected issues.

* **Bug Fixes**
  * Reduced the chance of startup failures by handling launch errors more gracefully.
  * Improved window behavior when restoring from the tray, with better positioning near the tray icon and fallback warnings if positioning fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->